### PR TITLE
Bump aws-sdk-go to v1.44.10-ROCKIT19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/hashicorp/terraform-provider-aws
 
 go 1.21
 
-replace github.com/aws/aws-sdk-go => github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT16
+replace github.com/aws/aws-sdk-go => github.com/C2Devel/aws-sdk-go v1.44.10-ROCKIT19
 
 require (
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.2


### PR DESCRIPTION
Bump aws-sdk-go to v1.44.10-ROCKIT19
- aws-sdk-go module is updated to v1.44.10-ROCKIT19