### PR TITLE
Bump aws-sdk-go to v1.44.10-ROCKIT22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/hashicorp/terraform-provider-aws
 
 go 1.21
 
-replace github.com/aws/aws-sdk-go => github.com/vamping111/aws-sdk-go v1.44.10-ROCKIT21
+replace github.com/aws/aws-sdk-go => github.com/vamping111/aws-sdk-go v1.44.10-ROCKIT22
 
 require (
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.2

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/vamping111/aws-sdk-go v1.44.10-ROCKIT21 h1:4QEYANxmm84AON1VRQpKNcSrU5QalMEGVIdiJ8v8kxA=
-github.com/vamping111/aws-sdk-go v1.44.10-ROCKIT21/go.mod h1:JCfES7rKS8ADm4DcmGHd2i0vL86B2b6rpVPkniCtJX8=
+github.com/vamping111/aws-sdk-go v1.44.10-ROCKIT22 h1:XSSwoj7AiP3xBYE+sTHZS2TuSsnWU+C4x7QJAP1VY1w=
+github.com/vamping111/aws-sdk-go v1.44.10-ROCKIT22/go.mod h1:JCfES7rKS8ADm4DcmGHd2i0vL86B2b6rpVPkniCtJX8=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
Bump aws-sdk-go to v1.44.10-ROCKIT22
- aws-sdk-go module is updated to v1.44.10-ROCKIT22